### PR TITLE
Update Anarchy to help users of Rainfall

### DIFF
--- a/FineRoadAnarchy/Detours/NetAIDetour.cs
+++ b/FineRoadAnarchy/Detours/NetAIDetour.cs
@@ -1,0 +1,24 @@
+
+using ColossalFramework;
+using ColossalFramework.Math;
+using System;
+
+using UnityEngine;
+
+using FineRoadAnarchy.Redirection;
+
+namespace FineRoadAnarchy.Detours
+{
+    [TargetType(typeof(NetAI))]
+    public class NetAIDetour : NetAI
+    {
+        [RedirectMethod]
+        public override bool BuildOnWater()
+        {
+            
+                return true;
+            
+        }
+        
+    }
+}

--- a/FineRoadAnarchy/FineRoadAnarchy.cs
+++ b/FineRoadAnarchy/FineRoadAnarchy.cs
@@ -169,7 +169,7 @@ namespace FineRoadAnarchy
                         Redirector<RoadAIDetour>.Deploy();
                         Redirector<PedestrianPathAIDetour>.Deploy();
                         Redirector<TrainTrackAIDetour>.Deploy();
-
+			Redirector<NetAIDetour>.Deploy();
                         if (chirperButton != null && chirperAtlasAnarchy != null)
                         {
                             chirperAtlasNormal = chirperButton.atlas;
@@ -184,7 +184,7 @@ namespace FineRoadAnarchy
                         Redirector<RoadAIDetour>.Revert();
                         Redirector<PedestrianPathAIDetour>.Revert();
                         Redirector<TrainTrackAIDetour>.Revert();
-
+			Redirector<NetAIDetour>.Revert();
                         if (chirperButton != null && chirperAtlasNormal != null)
                         {
                             chirperButton.atlas = chirperAtlasNormal;


### PR DESCRIPTION
Adds a detour for NetAI.BuildOnWater() to help Rainfall users that is activated with Anarchy. If you want we could also add a check to see if Rainfall is enabled. I can also include it in Rainfall, but I was having trouble figuring out how to get it to toggle with Anarchy. If you would know how to access the variable in your mod from mine that would also fix the problem. 