### PR TITLE
NetInfoDetour is deployed only when needed

### DIFF
--- a/FineRoadAnarchy/Detours/NetInfoDetour.cs
+++ b/FineRoadAnarchy/Detours/NetInfoDetour.cs
@@ -8,19 +8,7 @@ namespace FineRoadAnarchy.Detours
         [RedirectMethod]
         new public float GetMinNodeDistance()
         {
-            if(!FineRoadAnarchy.snapping)
-            {
-                return 3f;
-            }
-            if (this.m_halfWidth < 3.5f)
-            {
-                return 7f;
-            }
-            if (this.m_halfWidth < 7.5f)
-            {
-                return 15f;
-            }
-            return 23f;
+            return 3f;
         }
     }
 }

--- a/FineRoadAnarchy/FineRoadAnarchy.cs
+++ b/FineRoadAnarchy/FineRoadAnarchy.cs
@@ -61,7 +61,7 @@ namespace FineRoadAnarchy
                     }
                 }
 
-                Redirector<NetInfoDetour>.Deploy();
+                //Redirector<NetInfoDetour>.Deploy();
                 collision = (ToolManager.instance.m_properties.m_mode & ItemClass.Availability.AssetEditor) == ItemClass.Availability.None;
 
                 if (chirperAtlasAnarchy == null)
@@ -146,7 +146,7 @@ namespace FineRoadAnarchy
 
         public void OnDestroy()
         {
-            Redirector<NetInfoDetour>.Revert();
+            //Redirector<NetInfoDetour>.Revert();
             anarchy = false;
         }
 
@@ -215,7 +215,30 @@ namespace FineRoadAnarchy
             }
         }
 
-        public static bool snapping = true;
+        public static bool snapping
+        {
+            get
+            {
+                return !Redirector<NetInfoDetour>.IsDeployed();
+            }
+
+            set
+            {
+                if (value != snapping)
+                {
+                    if (value)
+                    {
+                        DebugUtils.Log("Enabling snapping");
+                        Redirector<NetInfoDetour>.Revert();
+                    }
+                    else
+                    {
+                        DebugUtils.Log("Disabling snapping");
+                        Redirector<NetInfoDetour>.Deploy();
+                    }
+                }
+            }
+        }
 
         public static bool collision
         {

--- a/FineRoadAnarchy/FineRoadAnarchy.csproj
+++ b/FineRoadAnarchy/FineRoadAnarchy.csproj
@@ -35,18 +35,21 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\ProgramFiles\Steam\SteamApps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="ColossalManaged">
-      <HintPath>..\..\..\ProgramFiles\Steam\SteamApps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
     </Reference>
     <Reference Include="ICities">
-      <HintPath>..\..\..\ProgramFiles\Steam\SteamApps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\ProgramFiles\Steam\SteamApps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi! I am author of [Smart Intersection Builder](https://steamcommunity.com/sharedfiles/filedetails/?id=1677913611) mod. I make use of your mod, but I have a problem. The no snapping option is good, but sometimes the value '3f' is still too big for my needs. I would like to set the value myself, but unlike from all other detours you use in your mod, the NetInfo detour is deployed all the time, even when it doesn't have to be.
Thus I cannot patch the GetMinNodeDistance method without rendering my mod incompatible with yours (which is the last thing I would want). Is there any reason for your implementation or could it be updated? I ran the new code on my computer without any apparent problems.
Thank you very much! I learned modding from people like you and I use plenty of your code in my mods. You are a legend! :)